### PR TITLE
Fix CSS reset and single checkboxes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## Next version
 
 - Adjusted the margins of single checkbox labels.
-
+- Fixed a bug that prevented some inputs from expanding to the width of its container.
+- Altered CSS reset to only target elements affected by semantic forms.
 
 ## 4.0.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ## Next version
 
-- Adjusted the margins of single checkbox labels.
+- Adjusted the margins of checkbox and radio labels.
 - Fixed a bug that prevented some inputs from expanding to the width of its container.
-- Altered CSS reset to only target elements affected by semantic forms.
+- Altered CSS reset to only target form elements within a semantic form.
 
 ## 4.0.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next version
 
-- Put your changes here...
+- Adjusted the margins of single checkbox labels.
 
 
 ## 4.0.2

--- a/semanticForms.css
+++ b/semanticForms.css
@@ -67,7 +67,7 @@ form.semanticForms menu:has(li > input, li > label, li > button, li > select, li
 form.semanticForms dl:has(dt > label, dd > input, dd > select, dd > textarea),
 form.semanticForms dt:has(> input, > select, > textarea),
 form.semanticForms dd:has(> input, > select, > textarea, > ul, > menu),
-form.semanticForms div,
+form.semanticForms div:has(dt, dd),
 form.semanticForms dd > p {
   color: var(--formTextColor);
   font-family: sans-serif;

--- a/semanticForms.css
+++ b/semanticForms.css
@@ -57,7 +57,18 @@ form.semanticForms {
   flex-direction: column;
   gap: 10px;
 }
-form.semanticForms fieldset, form.semanticForms label, form.semanticForms input, form.semanticForms select, form.semanticForms textarea, form.semanticForms button, form.semanticForms dl, form.semanticForms menu, form.semanticForms dt, form.semanticForms dd, form.semanticForms div, form.semanticForms dd > p {
+form.semanticForms fieldset,
+form.semanticForms label,
+form.semanticForms input,
+form.semanticForms select,
+form.semanticForms textarea,
+form.semanticForms button,
+form.semanticForms menu:has(li > input, li > label, li > button, li > select, li > textarea),
+form.semanticForms dl:has(dt > label, dd > input, dd > select, dd > textarea),
+form.semanticForms dt:has(> input, > select, > textarea),
+form.semanticForms dd:has(> input, > select, > textarea, > ul, > menu),
+form.semanticForms div,
+form.semanticForms dd > p {
   color: var(--formTextColor);
   font-family: sans-serif;
   box-sizing: border-box;
@@ -83,38 +94,38 @@ form.semanticForms fieldset > fieldset select,
 form.semanticForms fieldset > fieldset textarea {
   background: var(--nestedInput);
 }
-form.semanticForms dl {
+form.semanticForms dl:has(dt > label, dd > input, dd > select, dd > textarea) {
   display: grid;
   grid-template-columns: repeat(2, minmax(var(--inputMinWidth), 1fr));
   gap: 10px;
   margin-bottom: 10px;
 }
-form.semanticForms dl dd {
+form.semanticForms dl:has(dt > label, dd > input, dd > select, dd > textarea) dd {
   position: relative;
 }
-form.semanticForms dl dd:not(.checkboxes, .radios) {
+form.semanticForms dl:has(dt > label, dd > input, dd > select, dd > textarea) dd:not(.checkboxes, .radios) {
   gap: 10px;
   max-width: 100%;
 }
-form.semanticForms dl dd:not(.checkboxes, .radios):not(.singleCheckbox) {
+form.semanticForms dl:has(dt > label, dd > input, dd > select, dd > textarea) dd:not(.checkboxes, .radios):not(.singleCheckbox) {
   display: flex;
   flex-direction: column;
 }
-form.semanticForms dl dd:not(.checkboxes, .radios).singleCheckbox {
+form.semanticForms dl:has(dt > label, dd > input, dd > select, dd > textarea) dd:not(.checkboxes, .radios).singleCheckbox {
   display: flex;
   align-items: center;
 }
-form.semanticForms dl dd:not(.checkboxes, .radios).singleCheckbox > :not(input[type=checkbox], label) {
+form.semanticForms dl:has(dt > label, dd > input, dd > select, dd > textarea) dd:not(.checkboxes, .radios).singleCheckbox > :not(input[type=checkbox], label) {
   grid-column: 1/-1;
 }
-form.semanticForms dl dd.checkboxes ul, form.semanticForms dl dd.radios ul {
+form.semanticForms dl:has(dt > label, dd > input, dd > select, dd > textarea) dd.checkboxes ul, form.semanticForms dl:has(dt > label, dd > input, dd > select, dd > textarea) dd.radios ul {
   display: flex;
   flex-direction: column;
   margin-top: var(--inputTopMargin);
   padding-left: 10px;
   gap: 5px;
 }
-form.semanticForms dl dd.checkboxes ul li, form.semanticForms dl dd.radios ul li {
+form.semanticForms dl:has(dt > label, dd > input, dd > select, dd > textarea) dd.checkboxes ul li, form.semanticForms dl:has(dt > label, dd > input, dd > select, dd > textarea) dd.radios ul li {
   display: flex;
   align-items: center;
   gap: 5px;
@@ -130,7 +141,8 @@ form.semanticForms p:has(input[type=checkbox], input[type=radio]) {
   align-items: center;
   gap: 5px;
 }
-form.semanticForms menu, form.semanticForms ul {
+form.semanticForms menu:has(li > input),
+form.semanticForms ul:has(li > input) {
   display: flex;
   justify-content: space-between;
   flex-wrap: wrap;
@@ -284,8 +296,7 @@ form.semanticForms button:not(.clear):hover {
 }
 form.semanticForms input[type=checkbox] + label:first-of-type,
 form.semanticForms input[type=radio] + label:first-of-type {
-  padding: 2px 0;
-  line-height: var(--inputFontSize);
+  padding-top: 2px;
   font-size: var(--inputFontSize);
 }
 form.semanticForms .floatLabelForm div {
@@ -385,8 +396,10 @@ form.semanticForms .floatLabelForm div dt label {
   user-select: auto;
   color: var(--formTextColor);
   position: absolute;
-  transform: translateY(-100%) scale(0.8);
+  transform-origin: left center;
+  transform: translateY(-100%) scale(0.7);
   top: var(--inputTopMargin);
+  left: 10px;
 }
 form.semanticForms .floatLabelForm div:has(dd input:required) dt label > span {
   margin-left: 5px;

--- a/semanticForms.css
+++ b/semanticForms.css
@@ -119,15 +119,12 @@ form.semanticForms dl dd.checkboxes ul li, form.semanticForms dl dd.radios ul li
   align-items: center;
   gap: 5px;
 }
-form.semanticForms p input, form.semanticForms p select, form.semanticForms p textarea {
-  max-width: 350px;
-}
 form.semanticForms p:has(input:not([type=checkbox], [type=radio]), textarea, label) {
   display: flex;
   flex-direction: column;
   gap: 5px;
 }
-form.semanticForms p:has(input[type=checkbox], input[type=radio], label) {
+form.semanticForms p:has(input[type=checkbox], input[type=radio]) {
   display: flex;
   flex-direction: row;
   align-items: center;
@@ -290,9 +287,6 @@ form.semanticForms input[type=radio] + label:first-of-type {
   padding: 2px 0;
   line-height: var(--inputFontSize);
   font-size: var(--inputFontSize);
-}
-form.semanticForms .floatLabelForm:not(:has(div:nth-of-type(2))) dd:not(.checkboxes, .radios):not(:has(textarea)) {
-  max-width: 350px;
 }
 form.semanticForms .floatLabelForm div {
   position: relative;

--- a/semanticForms.css
+++ b/semanticForms.css
@@ -57,10 +57,10 @@ form.semanticForms {
   flex-direction: column;
   gap: 10px;
 }
-form.semanticForms * {
+form.semanticForms fieldset, form.semanticForms label, form.semanticForms input, form.semanticForms select, form.semanticForms textarea, form.semanticForms button, form.semanticForms dl, form.semanticForms menu, form.semanticForms dt, form.semanticForms dd, form.semanticForms div, form.semanticForms dd > p {
   color: var(--formTextColor);
-  box-sizing: border-box;
   font-family: sans-serif;
+  box-sizing: border-box;
   margin: 0;
   padding: 0;
 }
@@ -101,8 +101,8 @@ form.semanticForms dl dd:not(.checkboxes, .radios):not(.singleCheckbox) {
   flex-direction: column;
 }
 form.semanticForms dl dd:not(.checkboxes, .radios).singleCheckbox {
-  display: grid;
-  grid-template-columns: min-content 1fr;
+  display: flex;
+  align-items: center;
 }
 form.semanticForms dl dd:not(.checkboxes, .radios).singleCheckbox > :not(input[type=checkbox], label) {
   grid-column: 1/-1;
@@ -118,10 +118,6 @@ form.semanticForms dl dd.checkboxes ul li, form.semanticForms dl dd.radios ul li
   display: flex;
   align-items: center;
   gap: 5px;
-}
-form.semanticForms dl dd.checkboxes ul li label, form.semanticForms dl dd.radios ul li label {
-  font-size: var(--inputFontSize);
-  margin-top: 2px;
 }
 form.semanticForms p input, form.semanticForms p select, form.semanticForms p textarea {
   max-width: 350px;
@@ -201,6 +197,7 @@ form.semanticForms input[type=checkbox],
 form.semanticForms input[type=radio] {
   width: 1.4em;
   height: 1.4em;
+  margin: auto 0;
   cursor: pointer;
 }
 form.semanticForms input[type=checkbox] ~ label:first-of-type,
@@ -287,6 +284,12 @@ form.semanticForms input[type=reset]:hover,
 form.semanticForms input[type=image]:hover,
 form.semanticForms button:not(.clear):hover {
   filter: brightness(1.05);
+}
+form.semanticForms input[type=checkbox] + label:first-of-type,
+form.semanticForms input[type=radio] + label:first-of-type {
+  padding: 2px 0;
+  line-height: var(--inputFontSize);
+  font-size: var(--inputFontSize);
 }
 form.semanticForms .floatLabelForm:not(:has(div:nth-of-type(2))) dd:not(.checkboxes, .radios):not(:has(textarea)) {
   max-width: 350px;

--- a/semanticForms.html
+++ b/semanticForms.html
@@ -419,7 +419,37 @@
               Some regular text with <strong>other elements</strong> <span>inside of it</span>
             </p>
           </fieldset>
+
+          <h2>Non-form related HTML elements</h2>
+        <p>This is some regular HTML that should not be affected by any semantic forms styles</p>
+        <div>This is a div</div>
+        <blockquote>This is a block quote</blockquote>
+        <a href="https://github.com/rooseveltframework/semantic-forms">A link to the semantic forms repo</a>
+        <ul>
+          <li>unordered list 1</li>
+          <li>unordered list 2</li>
+          <li>unordered list 3</li>
+        </ul>
+        <ol>
+          <li>ordered list 1</li>
+          <li>ordered list 2</li>
+          <li>ordered list 3</li>
+        </ol>
+        <menu>
+          <li>menu list 1</li>
+          <li>menu list 2</li>
+          <li>menu list 3</li>
+        </menu>
+        <dl>
+          <dt>description list title</dt>
+          <dd>description list value</dd>
+        </dl>
+        <details>
+          <p>Some detail text</p>
+        </details>
         </form>
+
+        <hr>
 
         <h2>Low flow (JavaScript disabled) styling</h2>
         <p>Adding the <code>lowFlow</code> class to the form element removes all JS enhancements.</p>
@@ -787,47 +817,12 @@
               <li><input type="submit" name="button3" value="Button 3"></li>
             </menu>
           </fieldset>
-        </form>
-      </article>
 
-      <article>
-        <!-- standard elements -->
-        <h1>Header 1</h1>
-        <h2>Header 2</h2>
-        <h3>Header 3</h3>
-        <h4>Header 4</h4>
-        <h5>Header 5</h5>
-        <h6>Header 6</h6>
-
+          <h2>Non-form related HTML elements</h2>
         <p>This is some regular HTML that should not be affected by any semantic forms styles</p>
         <div>This is a div</div>
         <blockquote>This is a block quote</blockquote>
         <a href="https://github.com/rooseveltframework/semantic-forms">A link to the semantic forms repo</a>
-        <fieldset>
-          <legend>Fieldset</legend>
-          <p>Some text inside a fieldset</p>
-        </fieldset>
-
-        <!-- tables -->
-        <table>
-          <tr>
-            <th>1</th>
-            <th>2</th>
-            <th>3</th>
-          </tr>
-          <tr>
-            <td>A</td>
-            <td>B</td>
-            <td>C</td>
-          </tr>
-          <tr>
-            <td>D</td>
-            <td>E</td>
-            <td>F</td>
-          </tr>
-        </table>
-
-        <!-- lists -->
         <ul>
           <li>unordered list 1</li>
           <li>unordered list 2</li>
@@ -850,16 +845,7 @@
         <details>
           <p>Some detail text</p>
         </details>
-
-        <!-- form elements -->
-        <button>button</button>
-        <input type="text" placeholder="Text input">
-        <input type="number" placeholder="Number input">
-        <input type="color">
-        <input type="range">
-        <input type="date">
-        <label for="html-checkbox">HTML checkbox <input type="checkbox" name="html-checkbox" id="html-checkbox"></label>
-        <textarea placeholder="Text area"></textarea>
+        </form>
       </article>
     </main>
     <script>
@@ -871,9 +857,7 @@
 
         const forms = document.querySelectorAll('form')
         for (const form of forms) {
-          form.addEventListener('submit', e => {
-            e.preventDefault()
-          })
+          form.addEventListener('submit', e => e.preventDefault())
         }
 
         const greenButtons = document.querySelectorAll('input[type="image"]')

--- a/semanticForms.html
+++ b/semanticForms.html
@@ -30,19 +30,19 @@
         <form action="/somewhere" method="post" class="semanticForms">
           <dl>
             <dt><label for="name">Name</label></dt>
-              <dd><input id="name" name="name" type="text" placeholder="e.g. John Smith"></dd>
+            <dd><input id="name" name="name" type="text" placeholder="e.g. John Smith"></dd>
 
-              <dt><label for="prefilled">Prefilled field</label></dt>
-              <dd><input id="prefilled" name="prefilled" type="text" placeholder="e.g. Stuff" value="Some text prefilled"></dd>
+            <dt><label for="prefilled">Prefilled field</label></dt>
+            <dd><input id="prefilled" name="prefilled" type="text" placeholder="e.g. Stuff" value="Some text prefilled"></dd>
 
-              <dt><label for="noplaceholder">No placeholder</label></dt>
-              <dd><input id="noplaceholder" name="noplaceholder" type="text"></dd>
+            <dt><label for="noplaceholder">No placeholder</label></dt>
+            <dd><input id="noplaceholder" name="noplaceholder" type="text"></dd>
 
-              <dt><label for="password">Password field</label></dt>
-              <dd>
-                <input id="password" name="password" type="password" minlength="8" required>
-                <p data-invalid-text>Password should be at least 8 characters long.</p>
-              </dd>
+            <dt><label for="password">Password field</label></dt>
+            <dd>
+              <input id="password" name="password" type="password" minlength="8" required>
+              <p data-invalid-text>Password should be at least 8 characters long.</p>
+            </dd>
           </dl>
 
           <dl>
@@ -267,21 +267,16 @@
 
                 <dl>
                   <dt><label for="colspan-1-a">Input A</label></dt>
-                  <dd>
-                    <input type="text" id="colspan-1-a" name="colspan-1-a" placeholder="Some interesting placeholder text">
-                  </dd>
+                  <dd><input type="text" id="colspan-1-a" name="colspan-1-a" placeholder="Some interesting placeholder text"></dd>
+
                   <dt><label for="colspan-1-b">Input B</label></dt>
-                  <dd>
-                    <input type="text" id="colspan-1-b" name="colspan-1-b" placeholder="Some interesting placeholder text">
-                  </dd>
+                  <dd><input type="text" id="colspan-1-b" name="colspan-1-b" placeholder="Some interesting placeholder text"></dd>
+
                   <dt><label for="colspan-1-c">Input C</label></dt>
-                  <dd>
-                    <input type="text" id="colspan-1-c" name="colspan-1-c" placeholder="Some interesting placeholder text">
-                  </dd>
+                  <dd><input type="text" id="colspan-1-c" name="colspan-1-c" placeholder="Some interesting placeholder text"></dd>
+
                   <dt><label for="colspan-1-d">Input D</label></dt>
-                  <dd>
-                    <input type="text" id="colspan-1-d" name="colspan-1-d" placeholder="Some interesting placeholder text">
-                  </dd>
+                  <dd><input type="text" id="colspan-1-d" name="colspan-1-d" placeholder="Some interesting placeholder text"></dd>
                 </dl>
               </fieldset>
 
@@ -290,21 +285,16 @@
 
                 <dl>
                   <dt><label for="colspan-2-a">Input A</label></dt>
-                  <dd>
-                    <input type="text" id="colspan-2-a" name="colspan-2-a" placeholder="Some interesting placeholder text">
-                  </dd>
+                  <dd><input type="text" id="colspan-2-a" name="colspan-2-a" placeholder="Some interesting placeholder text"></dd>
+
                   <dt><label for="colspan-2-b">Input B</label></dt>
-                  <dd>
-                    <input type="text" id="colspan-2-b" name="colspan-2-b" placeholder="Some interesting placeholder text">
-                  </dd>
+                  <dd><input type="text" id="colspan-2-b" name="colspan-2-b" placeholder="Some interesting placeholder text"></dd>
+
                   <dt><label for="colspan-2-c">Input C</label></dt>
-                  <dd>
-                    <input type="text" id="colspan-2-c" name="colspan-2-c" placeholder="Some interesting placeholder text">
-                  </dd>
+                  <dd><input type="text" id="colspan-2-c" name="colspan-2-c" placeholder="Some interesting placeholder text"></dd>
+
                   <dt><label for="colspan-2-d">Input D</label></dt>
-                  <dd>
-                    <input type="text" id="colspan-2-d" name="colspan-2-d" placeholder="Some interesting placeholder text">
-                  </dd>
+                  <dd><input type="text" id="colspan-2-d" name="colspan-2-d" placeholder="Some interesting placeholder text"></dd>
                 </dl>
               </fieldset>
 
@@ -313,21 +303,16 @@
 
                 <dl class="colspan-3">
                   <dt><label for="colspan-3-a">Input A</label></dt>
-                  <dd>
-                    <input type="text" id="colspan-3-a" name="colspan-3-a" placeholder="Some interesting placeholder text">
-                  </dd>
+                  <dd><input type="text" id="colspan-3-a" name="colspan-3-a" placeholder="Some interesting placeholder text"></dd>
+
                   <dt><label for="colspan-3-b">Input B</label></dt>
-                  <dd>
-                    <input type="text" id="colspan-3-b" name="colspan-3-b" placeholder="Some interesting placeholder text">
-                  </dd>
+                  <dd><input type="text" id="colspan-3-b" name="colspan-3-b" placeholder="Some interesting placeholder text"></dd>
+
                   <dt><label for="colspan-3-c">Input C</label></dt>
-                  <dd>
-                    <input type="text" id="colspan-3-c" name="colspan-3-c" placeholder="Some interesting placeholder text">
-                  </dd>
+                  <dd><input type="text" id="colspan-3-c" name="colspan-3-c" placeholder="Some interesting placeholder text"></dd>
+
                   <dt><label for="colspan-3-d">Input D</label></dt>
-                  <dd>
-                    <input type="text" id="colspan-3-d" name="colspan-3-d" placeholder="Some interesting placeholder text">
-                  </dd>
+                  <dd><input type="text" id="colspan-3-d" name="colspan-3-d" placeholder="Some interesting placeholder text"></dd>
                 </dl>
               </fieldset>
 
@@ -336,21 +321,16 @@
 
                 <dl>
                   <dt><label for="colspan-full-a">Input A</label></dt>
-                  <dd>
-                    <input type="text" id="colspan-full-a" name="colspan-full-a" placeholder="Some interesting placeholder text">
-                  </dd>
+                  <dd><input type="text" id="colspan-full-a" name="colspan-full-a" placeholder="Some interesting placeholder text"></dd>
+
                   <dt><label for="colspan-full-b">Input B</label></dt>
-                  <dd>
-                    <input type="text" id="colspan-full-b" name="colspan-full-b" placeholder="Some interesting placeholder text">
-                  </dd>
+                  <dd><input type="text" id="colspan-full-b" name="colspan-full-b" placeholder="Some interesting placeholder text"></dd>
+
                   <dt><label for="colspan-full-c">Input C</label></dt>
-                  <dd>
-                    <input type="text" id="colspan-full-c" name="colspan-full-c" placeholder="Some interesting placeholder text">
-                  </dd>
+                  <dd><input type="text" id="colspan-full-c" name="colspan-full-c" placeholder="Some interesting placeholder text"></dd>
+
                   <dt><label for="colspan-full-d">Input D</label></dt>
-                  <dd>
-                    <input type="text" id="colspan-full-d" name="colspan-full-d" placeholder="Some interesting placeholder text">
-                  </dd>
+                  <dd><input type="text" id="colspan-full-d" name="colspan-full-d" placeholder="Some interesting placeholder text"></dd>
                 </dl>
               </fieldset>
             </fieldset>
@@ -421,32 +401,33 @@
           </fieldset>
 
           <h2>Non-form related HTML elements</h2>
-        <p>This is some regular HTML that should not be affected by any semantic forms styles</p>
-        <div>This is a div</div>
-        <blockquote>This is a block quote</blockquote>
-        <a href="https://github.com/rooseveltframework/semantic-forms">A link to the semantic forms repo</a>
-        <ul>
-          <li>unordered list 1</li>
-          <li>unordered list 2</li>
-          <li>unordered list 3</li>
-        </ul>
-        <ol>
-          <li>ordered list 1</li>
-          <li>ordered list 2</li>
-          <li>ordered list 3</li>
-        </ol>
-        <menu>
-          <li>menu list 1</li>
-          <li>menu list 2</li>
-          <li>menu list 3</li>
-        </menu>
-        <dl>
-          <dt>description list title</dt>
-          <dd>description list value</dd>
-        </dl>
-        <details>
-          <p>Some detail text</p>
-        </details>
+          <p>This is some regular HTML that should not be affected by any semantic forms styles</p>
+          <div>This is a div</div>
+          <blockquote>This is a block quote</blockquote>
+          <a href="https://github.com/rooseveltframework/semantic-forms">A link to the semantic forms repo</a>
+
+          <ul>
+            <li>unordered list 1</li>
+            <li>unordered list 2</li>
+            <li>unordered list 3</li>
+          </ul>
+          <ol>
+            <li>ordered list 1</li>
+            <li>ordered list 2</li>
+            <li>ordered list 3</li>
+          </ol>
+          <menu>
+            <li>menu list 1</li>
+            <li>menu list 2</li>
+            <li>menu list 3</li>
+          </menu>
+          <dl>
+            <dt>description list title</dt>
+            <dd>description list value</dd>
+          </dl>
+          <details>
+            <p>Some detail text</p>
+          </details>
         </form>
 
         <hr>
@@ -613,9 +594,7 @@
 
                 <dl>
                   <dt><label for="low-flow-nested-nested-input">Input</label></dt>
-                  <dd>
-                    <input type="text" id="low-flow-nested-nested-input" name="low-flow-nested-nested-input" placeholder="Some interesting placeholder text">
-                  </dd>
+                  <dd><input type="text" id="low-flow-nested-nested-input" name="low-flow-nested-nested-input" placeholder="Some interesting placeholder text"></dd>
                 </dl>
               </fieldset>
             </fieldset>
@@ -819,32 +798,32 @@
           </fieldset>
 
           <h2>Non-form related HTML elements</h2>
-        <p>This is some regular HTML that should not be affected by any semantic forms styles</p>
-        <div>This is a div</div>
-        <blockquote>This is a block quote</blockquote>
-        <a href="https://github.com/rooseveltframework/semantic-forms">A link to the semantic forms repo</a>
-        <ul>
-          <li>unordered list 1</li>
-          <li>unordered list 2</li>
-          <li>unordered list 3</li>
-        </ul>
-        <ol>
-          <li>ordered list 1</li>
-          <li>ordered list 2</li>
-          <li>ordered list 3</li>
-        </ol>
-        <menu>
-          <li>menu list 1</li>
-          <li>menu list 2</li>
-          <li>menu list 3</li>
-        </menu>
-        <dl>
-          <dt>description list title</dt>
-          <dd>description list value</dd>
-        </dl>
-        <details>
-          <p>Some detail text</p>
-        </details>
+          <p>This is some regular HTML that should not be affected by any semantic forms styles</p>
+          <div>This is a div</div>
+          <blockquote>This is a block quote</blockquote>
+          <a href="https://github.com/rooseveltframework/semantic-forms">A link to the semantic forms repo</a>
+          <ul>
+            <li>unordered list 1</li>
+            <li>unordered list 2</li>
+            <li>unordered list 3</li>
+          </ul>
+          <ol>
+            <li>ordered list 1</li>
+            <li>ordered list 2</li>
+            <li>ordered list 3</li>
+          </ol>
+          <menu>
+            <li>menu list 1</li>
+            <li>menu list 2</li>
+            <li>menu list 3</li>
+          </menu>
+          <dl>
+            <dt>description list title</dt>
+            <dd>description list value</dd>
+          </dl>
+          <details>
+            <p>Some detail text</p>
+          </details>
         </form>
       </article>
     </main>

--- a/semanticForms.html
+++ b/semanticForms.html
@@ -16,11 +16,6 @@
         background-color: #000;
         color: #fff;
       }
-      h1,
-      h2,
-      p {
-        font-family: sans-serif;
-      }
     </style>
     <script src="semanticForms.js"></script>
   </head>
@@ -793,6 +788,78 @@
             </menu>
           </fieldset>
         </form>
+      </article>
+
+      <article>
+        <!-- standard elements -->
+        <h1>Header 1</h1>
+        <h2>Header 2</h2>
+        <h3>Header 3</h3>
+        <h4>Header 4</h4>
+        <h5>Header 5</h5>
+        <h6>Header 6</h6>
+
+        <p>This is some regular HTML that should not be affected by any semantic forms styles</p>
+        <div>This is a div</div>
+        <blockquote>This is a block quote</blockquote>
+        <a href="https://github.com/rooseveltframework/semantic-forms">A link to the semantic forms repo</a>
+        <fieldset>
+          <legend>Fieldset</legend>
+          <p>Some text inside a fieldset</p>
+        </fieldset>
+
+        <!-- tables -->
+        <table>
+          <tr>
+            <th>1</th>
+            <th>2</th>
+            <th>3</th>
+          </tr>
+          <tr>
+            <td>A</td>
+            <td>B</td>
+            <td>C</td>
+          </tr>
+          <tr>
+            <td>D</td>
+            <td>E</td>
+            <td>F</td>
+          </tr>
+        </table>
+
+        <!-- lists -->
+        <ul>
+          <li>unordered list 1</li>
+          <li>unordered list 2</li>
+          <li>unordered list 3</li>
+        </ul>
+        <ol>
+          <li>ordered list 1</li>
+          <li>ordered list 2</li>
+          <li>ordered list 3</li>
+        </ol>
+        <menu>
+          <li>menu list 1</li>
+          <li>menu list 2</li>
+          <li>menu list 3</li>
+        </menu>
+        <dl>
+          <dt>description list title</dt>
+          <dd>description list value</dd>
+        </dl>
+        <details>
+          <p>Some detail text</p>
+        </details>
+
+        <!-- form elements -->
+        <button>button</button>
+        <input type="text" placeholder="Text input">
+        <input type="number" placeholder="Number input">
+        <input type="color">
+        <input type="range">
+        <input type="date">
+        <label for="html-checkbox">HTML checkbox <input type="checkbox" name="html-checkbox" id="html-checkbox"></label>
+        <textarea placeholder="Text area"></textarea>
       </article>
     </main>
     <script>

--- a/semanticForms.scss
+++ b/semanticForms.scss
@@ -62,7 +62,6 @@ form.semanticForms {
 
   // style reset
   fieldset, label, input, select, textarea, button, dl, menu, dt, dd, div, dd > p {
-  // * {
     color: var(--formTextColor);
     font-family: sans-serif;
     box-sizing: border-box;
@@ -141,10 +140,6 @@ form.semanticForms {
   }
 
   p {
-    input, select, textarea {
-      max-width: 350px;
-    }
-
     // input/label combo
     &:has(input:not([type='checkbox'], [type='radio']), textarea, label) {
       display: flex;
@@ -153,7 +148,7 @@ form.semanticForms {
     }
 
     // checkbox or radio/label combo
-    &:has(input[type='checkbox'], input[type='radio'], label) {
+    &:has(input[type='checkbox'], input[type='radio']) {
       display: flex;
       flex-direction: row;
       align-items: center;
@@ -342,20 +337,12 @@ form.semanticForms {
   input[type=checkbox] + label:first-of-type,
   input[type=radio] + label:first-of-type {
     // shift text down to match center
-    // height: 1em;
-    // margin: auto 0;
     padding: 2px 0;
     line-height: var(--inputFontSize);
     font-size: var(--inputFontSize);
   }
 
   .floatLabelForm {
-    &:not(:has(div:nth-of-type(2))) {
-      dd:not(.checkboxes, .radios):not(:has(textarea)) {
-        max-width: 350px;
-      }
-    }
-
     div {
       position: relative;
       width: 100%;

--- a/semanticForms.scss
+++ b/semanticForms.scss
@@ -71,7 +71,7 @@ form.semanticForms {
   dl:has(dt > label, dd > input, dd > select, dd > textarea),
   dt:has(> input, > select, > textarea),
   dd:has(> input, > select, > textarea, > ul, > menu),
-  div,
+  div:has(dt, dd),
   dd > p {
     color: var(--formTextColor);
     font-family: sans-serif;

--- a/semanticForms.scss
+++ b/semanticForms.scss
@@ -61,7 +61,18 @@ form.semanticForms {
   gap: 10px;
 
   // style reset
-  fieldset, label, input, select, textarea, button, dl, menu, dt, dd, div, dd > p {
+  fieldset,
+  label,
+  input,
+  select,
+  textarea,
+  button,
+  menu:has(li > input, li > label, li > button, li > select, li > textarea),
+  dl:has(dt > label, dd > input, dd > select, dd > textarea),
+  dt:has(> input, > select, > textarea),
+  dd:has(> input, > select, > textarea, > ul, > menu),
+  div,
+  dd > p {
     color: var(--formTextColor);
     font-family: sans-serif;
     box-sizing: border-box;
@@ -94,7 +105,7 @@ form.semanticForms {
     }
   }
 
-  dl {
+  dl:has(dt > label, dd > input, dd > select, dd > textarea) {
     display: grid;
     grid-template-columns: repeat(2, minmax(var(--inputMinWidth), 1fr));
     gap: 10px;
@@ -156,7 +167,8 @@ form.semanticForms {
     }
   }
 
-  menu, ul {
+  menu:has(li > input),
+  ul:has(li > input) {
     display: flex;
     justify-content: space-between;
     flex-wrap: wrap;
@@ -337,8 +349,7 @@ form.semanticForms {
   input[type=checkbox] + label:first-of-type,
   input[type=radio] + label:first-of-type {
     // shift text down to match center
-    padding: 2px 0;
-    line-height: var(--inputFontSize);
+    padding-top: 2px;
     font-size: var(--inputFontSize);
   }
 
@@ -458,8 +469,10 @@ form.semanticForms {
           user-select: auto;
           color: var(--formTextColor);
           position: absolute;
-          transform: translateY(-100%) scale(0.8);
+          transform-origin: left center;
+          transform: translateY(-100%) scale(0.7);
           top: var(--inputTopMargin);
+          left: 10px;
         }
       }
 

--- a/semanticForms.scss
+++ b/semanticForms.scss
@@ -61,10 +61,11 @@ form.semanticForms {
   gap: 10px;
 
   // style reset
-  * {
+  fieldset, label, input, select, textarea, button, dl, menu, dt, dd, div, dd > p {
+  // * {
     color: var(--formTextColor);
-    box-sizing: border-box;
     font-family: sans-serif;
+    box-sizing: border-box;
     margin: 0;
     padding: 0;
   }
@@ -114,8 +115,8 @@ form.semanticForms {
         }
 
         &.singleCheckbox {
-          display: grid;
-          grid-template-columns: min-content 1fr;
+          display: flex;
+          align-items: center;
 
           & > :not(input[type='checkbox'], label) {
             grid-column: 1 / -1;
@@ -134,12 +135,6 @@ form.semanticForms {
           display: flex;
           align-items: center;
           gap: 5px;
-
-          label {
-            // shift text down to match center
-            font-size: var(--inputFontSize);
-            margin-top: 2px;
-          }
         }
       }
     }
@@ -241,6 +236,7 @@ form.semanticForms {
     // 30% larger based on parent font size
     width: 1.4em;
     height: 1.4em;
+    margin: auto 0;
     cursor: pointer;
 
     & ~ label:first-of-type {
@@ -342,6 +338,17 @@ form.semanticForms {
   // #endregion
 
   // #region labels
+
+  input[type=checkbox] + label:first-of-type,
+  input[type=radio] + label:first-of-type {
+    // shift text down to match center
+    // height: 1em;
+    // margin: auto 0;
+    padding: 2px 0;
+    line-height: var(--inputFontSize);
+    font-size: var(--inputFontSize);
+  }
+
   .floatLabelForm {
     &:not(:has(div:nth-of-type(2))) {
       dd:not(.checkboxes, .radios):not(:has(textarea)) {
@@ -754,13 +761,13 @@ form.semanticForms {
 
         // nudge single checkboxes to match checkbox groups
         &:not(.checkboxes) {
-          input[type="checkbox"] {
+          input[type=checkbox] {
             margin-left: 10px;
           }
         }
 
         // remove "x" padding
-        input:not([type='submit'], [type='reset'], [type='image'], [type=checkbox], [type=radio], [type="range"]),
+        input:not([type=submit], [type=reset], [type=image], [type=checkbox], [type=radio], [type=range]),
         select,
         textarea {
           padding-right: 6px;


### PR DESCRIPTION
- Adjusted the margins of single checkbox labels. (closes #97)
- Fixed a bug that prevented some inputs from expanding to the width of its container.
- Altered CSS reset to only target elements affected by semantic forms. (closes #98)