### PR TITLE
5.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,15 @@
 
 ## Next version
 
+- Put your changes here...
+
+## 5.0.2
+
 - Fixed a bug that would cause errors when `reinitialize()` was called.
 - Fixed a bug that caused nested selects to lose their dropdown icon.
 - Fixed a bug where required single checkboxes would not show an asterisk.
 - Added a help text icon beside labels with a `title` attribute on their respective inputs, or on labels for checkboxes and radios. Enabled with a `data-show-help-icon` attribute.
+- Updated various dependencies.
 
 ## 5.0.1
 

--- a/README.md
+++ b/README.md
@@ -46,12 +46,12 @@ Then apply the `semanticForms` class to your `<form>` elements:
 Then apply the JavaScript enhancements:
 
 ```javascript
-window.semanticForms()
+semanticForms()
 ```
 
 Then the CSS/JS enhancements to your forms will apply automatically, assuming the markup structure you use is one of the supported patterns.
 
-If you make changes to the DOM after Semantic Forms is activated and want to activate any additional `semanticForms` forms you insert, you can re-scan for new forms by calling `window.semanticForms()` again. If you only want to reinitialize one form instead of all of them, call `window.semanticForms.reinitialize(formElement)`.
+If you make changes to the DOM after Semantic Forms is activated and want to activate any additional `semanticForms` forms you insert, you can re-scan for new forms by calling `semanticForms.reinitialize()` again. If you only want to reinitialize one form instead of all of them, call `semanticForms.reinitialize(formElement)`.
 
 # Features
 
@@ -110,9 +110,8 @@ By default, input fields will display an X icon to clear the text and password f
 - Prevent the show/hide toggle from appearing on password fields by applying a `data-no-reveal` attribute to the input.
 
 - Show a help text icon next to labels of inputs that contain a `title` attribute by applying a `data-show-help-icon` attribute to the label.
+  
   - Note that checkboxes and radios should have a `title` attribute on the label instead of the inputs.
-
-
 
 ## Responsive columns
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "semantic-forms",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "semantic-forms",
-      "version": "5.0.1",
+      "version": "5.0.2",
       "license": "CC-BY-4.0",
       "devDependencies": {
         "@jsdevtools/coverage-istanbul-loader": "3.0.5",
@@ -1127,9 +1127,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.13.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.5.tgz",
-      "integrity": "sha512-+lTU0PxZXn0Dr1NBtC7Y8cR21AJr87dLLU953CWA6pMxxv/UDc7jYAY90upcrie1nRcD6XNG5HOYEDtgW5TxAg==",
+      "version": "22.13.8",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.8.tgz",
+      "integrity": "sha512-G3EfaZS+iOGYWLLRCEAXdWK9my08oHNZ+FHluRiggIYJPOXzhOiDgpVCUHaUvyIC5/fj7C/p637jdzC666AOKQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -2870,9 +2870,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.107",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.107.tgz",
-      "integrity": "sha512-dJr1o6yCntRkXElnhsHh1bAV19bo/hKyFf7tCcWgpXbuFIF0Lakjgqv5LRfSDaNzAII8Fnxg2tqgHkgCvxdbxw==",
+      "version": "1.5.109",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.109.tgz",
+      "integrity": "sha512-AidaH9JETVRr9DIPGfp1kAarm/W6hRJTPuCnkF+2MqhF4KaAgRIcBc8nvjk+YMXZhwfISof/7WG29eS4iGxQLQ==",
       "dev": true,
       "license": "ISC"
     },

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
       "url": "https://github.com/rooseveltframework/semantic-forms/graphs/contributors"
     }
   ],
-  "version": "5.0.1",
+  "version": "5.0.2",
   "files": [
     "dist",
     "semanticForms.scss"


### PR DESCRIPTION
- Fixed a bug that would cause errors when `reinitialize()` was called.
- Fixed a bug that caused nested selects to lose their dropdown icon.
- Fixed a bug where required single checkboxes would not show an asterisk.
- Added a help text icon beside labels with a `title` attribute on their respective inputs, or on labels for checkboxes and radios. Enabled with a `data-show-help-icon` attribute.
- Updated various dependencies.