### PR TITLE
Update textarea, forced styles, and input padding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Next version
+
+- Updated textarea elements to autosize based on input text, can be disabled with `data-no-autosize` attribute. Row count can be limited with `data-max-rows` attribute.
+- Fixed a visual bug where number input up/down arrows would be shifted when the clear button was not visible.
+- Fixed a bug where forms with an explicit light/dark class would be overwritten by the system preference.
+
 ## 5.1.5
 
 - Added `no-float-label` class to disable float labels on a per input basis.

--- a/dist/semantic-forms.css
+++ b/dist/semantic-forms.css
@@ -210,6 +210,20 @@ table.semanticForms.light textarea {
   touch-action: manipulation;
   outline: none;
 }
+form.semanticForms input:not([type=submit], [type=reset], [type=image], [type=checkbox], [type=radio]):not([type=range]):placeholder-shown,
+form.semanticForms select:not([type=range]):placeholder-shown,
+form.semanticForms textarea:not([type=range]):placeholder-shown,
+form.semanticForms.light input:not([type=submit], [type=reset], [type=image], [type=checkbox], [type=radio]):not([type=range]):placeholder-shown,
+form.semanticForms.light select:not([type=range]):placeholder-shown,
+form.semanticForms.light textarea:not([type=range]):placeholder-shown,
+table.semanticForms input:not([type=submit], [type=reset], [type=image], [type=checkbox], [type=radio]):not([type=range]):placeholder-shown,
+table.semanticForms select:not([type=range]):placeholder-shown,
+table.semanticForms textarea:not([type=range]):placeholder-shown,
+table.semanticForms.light input:not([type=submit], [type=reset], [type=image], [type=checkbox], [type=radio]):not([type=range]):placeholder-shown,
+table.semanticForms.light select:not([type=range]):placeholder-shown,
+table.semanticForms.light textarea:not([type=range]):placeholder-shown {
+  padding: 6px 20px;
+}
 form.semanticForms input:not([type=submit], [type=reset], [type=image], [type=checkbox], [type=radio]):not([type=range]),
 form.semanticForms select:not([type=range]),
 form.semanticForms textarea:not([type=range]),
@@ -248,6 +262,31 @@ table.semanticForms.light select[type=text]:has(~ button.show),
 table.semanticForms.light textarea[type=password],
 table.semanticForms.light textarea[type=text]:has(~ button.show) {
   padding: 6px 55px 6px 20px;
+}
+form.semanticForms input:not([type=submit], [type=reset], [type=image], [type=checkbox], [type=radio])[type=range], form.semanticForms input:not([type=submit], [type=reset], [type=image], [type=checkbox], [type=radio])[type=color],
+form.semanticForms select[type=range],
+form.semanticForms select[type=color],
+form.semanticForms textarea[type=range],
+form.semanticForms textarea[type=color],
+form.semanticForms.light input:not([type=submit], [type=reset], [type=image], [type=checkbox], [type=radio])[type=range],
+form.semanticForms.light input:not([type=submit], [type=reset], [type=image], [type=checkbox], [type=radio])[type=color],
+form.semanticForms.light select[type=range],
+form.semanticForms.light select[type=color],
+form.semanticForms.light textarea[type=range],
+form.semanticForms.light textarea[type=color],
+table.semanticForms input:not([type=submit], [type=reset], [type=image], [type=checkbox], [type=radio])[type=range],
+table.semanticForms input:not([type=submit], [type=reset], [type=image], [type=checkbox], [type=radio])[type=color],
+table.semanticForms select[type=range],
+table.semanticForms select[type=color],
+table.semanticForms textarea[type=range],
+table.semanticForms textarea[type=color],
+table.semanticForms.light input:not([type=submit], [type=reset], [type=image], [type=checkbox], [type=radio])[type=range],
+table.semanticForms.light input:not([type=submit], [type=reset], [type=image], [type=checkbox], [type=radio])[type=color],
+table.semanticForms.light select[type=range],
+table.semanticForms.light select[type=color],
+table.semanticForms.light textarea[type=range],
+table.semanticForms.light textarea[type=color] {
+  cursor: pointer;
 }
 form.semanticForms input:not([type=submit], [type=reset], [type=image], [type=checkbox], [type=radio])[disabled],
 form.semanticForms select[disabled],
@@ -404,9 +443,9 @@ form.semanticForms.light textarea,
 table.semanticForms textarea,
 table.semanticForms.light textarea {
   resize: vertical;
+  line-height: 1.5;
   width: 100%;
   min-height: 38px;
-  height: 100px;
 }
 form.semanticForms input[type=search],
 form.semanticForms.light input[type=search],
@@ -934,6 +973,10 @@ table.semanticForms.light input[type=checkbox] + label:first-of-type,
 table.semanticForms.light input[type=radio] + label:first-of-type {
   padding-top: 2px;
   font-size: var(--semanticFormsInputFontSize);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 5px;
 }
 form.semanticForms input[type=checkbox] + label:first-of-type span.required,
 form.semanticForms input[type=radio] + label:first-of-type span.required,
@@ -957,6 +1000,16 @@ table.semanticForms.light input[type=checkbox] + label:first-of-type span.help,
 table.semanticForms.light input[type=radio] + label:first-of-type span.help {
   cursor: help;
   pointer-events: auto;
+}
+form.semanticForms input[type=checkbox] + label:first-of-type span.help svg,
+form.semanticForms input[type=radio] + label:first-of-type span.help svg,
+form.semanticForms.light input[type=checkbox] + label:first-of-type span.help svg,
+form.semanticForms.light input[type=radio] + label:first-of-type span.help svg,
+table.semanticForms input[type=checkbox] + label:first-of-type span.help svg,
+table.semanticForms input[type=radio] + label:first-of-type span.help svg,
+table.semanticForms.light input[type=checkbox] + label:first-of-type span.help svg,
+table.semanticForms.light input[type=radio] + label:first-of-type span.help svg {
+  width: 80%;
 }
 form.semanticForms .floatLabelForm,
 form.semanticForms.light .floatLabelForm,
@@ -1175,6 +1228,9 @@ table.semanticForms.light .floatLabelForm div dd:not(.singleCheckbox, .singleRad
   user-select: none;
   color: var(--semanticFormsPlaceholderColor);
   touch-action: manipulation;
+  display: flex;
+  align-items: center;
+  gap: 5px;
 }
 form.semanticForms .floatLabelForm div dd:not(.singleCheckbox, .singleRadio, .checkboxes, .radios) label:first-of-type span.required,
 form.semanticForms.light .floatLabelForm div dd:not(.singleCheckbox, .singleRadio, .checkboxes, .radios) label:first-of-type span.required,
@@ -1190,6 +1246,12 @@ table.semanticForms .floatLabelForm div dd:not(.singleCheckbox, .singleRadio, .c
 table.semanticForms.light .floatLabelForm div dd:not(.singleCheckbox, .singleRadio, .checkboxes, .radios) label:first-of-type span.help {
   cursor: help;
   pointer-events: auto;
+}
+form.semanticForms .floatLabelForm div dd:not(.singleCheckbox, .singleRadio, .checkboxes, .radios) label:first-of-type span.help svg,
+form.semanticForms.light .floatLabelForm div dd:not(.singleCheckbox, .singleRadio, .checkboxes, .radios) label:first-of-type span.help svg,
+table.semanticForms .floatLabelForm div dd:not(.singleCheckbox, .singleRadio, .checkboxes, .radios) label:first-of-type span.help svg,
+table.semanticForms.light .floatLabelForm div dd:not(.singleCheckbox, .singleRadio, .checkboxes, .radios) label:first-of-type span.help svg {
+  width: 80%;
 }
 form.semanticForms .floatLabelForm div dt,
 form.semanticForms.light .floatLabelForm div dt,

--- a/dist/semantic-forms.css
+++ b/dist/semantic-forms.css
@@ -32,7 +32,7 @@ form.semanticForms, form.semanticForms.light, table.semanticForms {
 }
 
 @media (prefers-color-scheme: dark) {
-  html:not(.light) body:not(.light) form.semanticForms, html:not(.light) body:not(.light) table.semanticForms {
+  html:not(.light) body:not(.light) form.semanticForms:not(.light), html:not(.light) body:not(.light) table.semanticForms:not(.light) {
     --semanticFormsFormBgColor: #555;
     --inputBackgroudColor: rgba(85,85,85,0.1);
     --semanticFormsFormSubBgColor: #2f2f2f;
@@ -57,7 +57,7 @@ form.semanticForms, form.semanticForms.light, table.semanticForms {
     --semanticFormsCustomResizer: url("data:image/svg+xml;utf8,%3Csvg width='20' height='20' viewBox='0 0 5.2916665 5.2916666' version='1.1' id='svg5' xmlns='http://www.w3.org/2000/svg' xmlns:svg='http://www.w3.org/2000/svg'%3E%3Cdefs id='defs2' /%3E%3Cg id='layer1'%3E%3Cpath style='fill:%23c9c9c9;stroke:%23c9c9c9;stroke-width:0.264583;stroke-dasharray:none;stroke-opacity:1' d='M 2.8245112,5.0994569 C 4.9396993,2.9842685 4.9396993,2.9842685 4.9396993,2.9842685' id='path1034' /%3E%3Cpath style='fill:%23c9c9c9;stroke:%23c9c9c9;stroke-width:0.264583;stroke-dasharray:none;stroke-opacity:1' d='M 1.515747,5.0406977 C 4.8873304,1.6691138 4.8873304,1.6691138 4.8873304,1.6691138' id='path1034-1' /%3E%3Cpath style='fill:%23c9c9c9;stroke:%23c9c9c9;stroke-width:0.264583;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1' d='M 0.20657789,5.0909782 C 4.9312207,0.3663348 4.9312207,0.3663348 4.9312207,0.3663348' id='path1034-9' /%3E%3C/g%3E%3C/svg%3E");
     --semanticFormsSearchIcon: url("data:image/svg+xml,%3Csvg%20width%3D%2214px%22%20height%3D%2214px%22%20viewBox%3D%220%200%2024%2024%22%20fill%3D%22none%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20d%3D%22M15.7955%2015.8111L21%2021M18%2010.5C18%2014.6421%2014.6421%2018%2010.5%2018C6.35786%2018%203%2014.6421%203%2010.5C3%206.35786%206.35786%203%2010.5%203C14.6421%203%2018%206.35786%2018%2010.5Z%22%20stroke%3D%22%23FFFFFF%22%20stroke-width%3D%222%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%2F%3E%3C%2Fsvg%3E");
   }
-  html:not(.light) body:not(.light) form.semanticForms input::-webkit-calendar-picker-indicator, html:not(.light) body:not(.light) table.semanticForms input::-webkit-calendar-picker-indicator {
+  html:not(.light) body:not(.light) form.semanticForms:not(.light) input::-webkit-calendar-picker-indicator, html:not(.light) body:not(.light) table.semanticForms:not(.light) input::-webkit-calendar-picker-indicator {
     filter: invert(100%);
   }
 }
@@ -87,6 +87,35 @@ html:not(.light) body:not(.light) form.semanticForms.dark, html:not(.light) body
   --semanticFormsSearchIcon: url("data:image/svg+xml,%3Csvg%20width%3D%2214px%22%20height%3D%2214px%22%20viewBox%3D%220%200%2024%2024%22%20fill%3D%22none%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20d%3D%22M15.7955%2015.8111L21%2021M18%2010.5C18%2014.6421%2014.6421%2018%2010.5%2018C6.35786%2018%203%2014.6421%203%2010.5C3%206.35786%206.35786%203%2010.5%203C14.6421%203%2018%206.35786%2018%2010.5Z%22%20stroke%3D%22%23FFFFFF%22%20stroke-width%3D%222%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%2F%3E%3C%2Fsvg%3E");
 }
 html:not(.light) body:not(.light) form.semanticForms.dark input::-webkit-calendar-picker-indicator, html:not(.light) body:not(.light) table.semanticForms.dark input::-webkit-calendar-picker-indicator {
+  filter: invert(100%);
+}
+
+form.semanticForms.dark, table.semanticForms.dark {
+  --semanticFormsFormBgColor: #555;
+  --inputBackgroudColor: rgba(85,85,85,0.1);
+  --semanticFormsFormSubBgColor: #2f2f2f;
+  --semanticFormsTextColor: #fff;
+  --semanticFormsBorderColor: #656565;
+  --semanticFormsSubBorderColor: #3f3f3f;
+  --semanticFormsPlaceholderColor: rgba(255, 255, 255, 0.85);
+  --semanticFormsScrollbarColor: #373737;
+  --semanticFormsClearButtonColor: #fff;
+  --semanticFormsButtonGradientLight: #6f6f6f;
+  --semanticFormsButtonGradientDark: #373737;
+  --semanticFormsNestedFieldsetBgColor: rgba(255, 255, 255, .05);
+  --semanticFormsNestedFieldsetBorder: 1px rgba(255, 255, 255, .1) solid;
+  --semanticFormsNestedInputBgColor: rgba(255, 255, 255, .15);
+  --semanticFormsBorder: none;
+  --semanticFormsTableTitleColor: #3f3f3f;
+  --semanticFormsTableHeaderColor: #4f4f4f;
+  --semanticFormsTableOddColor: #3f3f3f;
+  --semanticFormsTableEvenColor: #4f4f4f;
+  --semanticFormsTableBorder: 1px #656565 solid;
+  --semanticFormsSelectIcon: url("data:image/svg+xml;utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='100' height='100' fill='%23fff'%3E%3Cpolygon stroke='%23fff' points='0,0 100,0 50,50'/%3E%3C/svg%3E");
+  --semanticFormsCustomResizer: url("data:image/svg+xml;utf8,%3Csvg width='20' height='20' viewBox='0 0 5.2916665 5.2916666' version='1.1' id='svg5' xmlns='http://www.w3.org/2000/svg' xmlns:svg='http://www.w3.org/2000/svg'%3E%3Cdefs id='defs2' /%3E%3Cg id='layer1'%3E%3Cpath style='fill:%23c9c9c9;stroke:%23c9c9c9;stroke-width:0.264583;stroke-dasharray:none;stroke-opacity:1' d='M 2.8245112,5.0994569 C 4.9396993,2.9842685 4.9396993,2.9842685 4.9396993,2.9842685' id='path1034' /%3E%3Cpath style='fill:%23c9c9c9;stroke:%23c9c9c9;stroke-width:0.264583;stroke-dasharray:none;stroke-opacity:1' d='M 1.515747,5.0406977 C 4.8873304,1.6691138 4.8873304,1.6691138 4.8873304,1.6691138' id='path1034-1' /%3E%3Cpath style='fill:%23c9c9c9;stroke:%23c9c9c9;stroke-width:0.264583;stroke-linecap:butt;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1' d='M 0.20657789,5.0909782 C 4.9312207,0.3663348 4.9312207,0.3663348 4.9312207,0.3663348' id='path1034-9' /%3E%3C/g%3E%3C/svg%3E");
+  --semanticFormsSearchIcon: url("data:image/svg+xml,%3Csvg%20width%3D%2214px%22%20height%3D%2214px%22%20viewBox%3D%220%200%2024%2024%22%20fill%3D%22none%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20d%3D%22M15.7955%2015.8111L21%2021M18%2010.5C18%2014.6421%2014.6421%2018%2010.5%2018C6.35786%2018%203%2014.6421%203%2010.5C3%206.35786%206.35786%203%2010.5%203C14.6421%203%2018%206.35786%2018%2010.5Z%22%20stroke%3D%22%23FFFFFF%22%20stroke-width%3D%222%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%2F%3E%3C%2Fsvg%3E");
+}
+form.semanticForms.dark input::-webkit-calendar-picker-indicator, table.semanticForms.dark input::-webkit-calendar-picker-indicator {
   filter: invert(100%);
 }
 

--- a/dist/semantic-forms.js
+++ b/dist/semantic-forms.js
@@ -42,7 +42,7 @@ if(input.nodeName==="TEXTAREA"){if(input.getAttribute("data-disable-autosize")==
 // add auto-sizing
 input.style.setProperty("resize","none");input.style.setProperty("min-height","0");input.style.setProperty("max-height","none");input.style.setProperty("height","auto");const handleInput=()=>{
 // reset rows attribute to get accurate scrollHeight
-input.setAttribute("rows","1");
+let maxRows=input.getAttribute("data-max-rows");if(maxRows)if(isNaN(maxRows)||Number(maxRows)<=0){console.warn(`An invalid value was passed to the "data-max-rows" attribute. This value will be ignored.\n\nProvided value: ${input.getAttribute("data-max-rows")}`);maxRows=null}const minRows=input.getAttribute("data-max-rows")&&Number(input.getAttribute("data-max-rows"))<5?input.getAttribute("data-max-rows"):"5";input.setAttribute("rows",minRows);
 // get the computed values object reference
 const style=window.getComputedStyle(input);
 // force content-box for size accurate line-height calculation, remove scrollbars, lock width (subtract inline padding and inline border widths), and remove inline padding and borders to keep width consistent (for text wrapping accuracy)
@@ -56,7 +56,7 @@ input.style.removeProperty("width");input.style.removeProperty("box-sizing");inp
 // subtract blockPadding from scrollHeight and divide that by our lineHeight to get the row count, round to nearest integer as it will always be within ~.1 of the correct whole number
 const rows=Math.round((scrollHeight-blockPadding)/lineHeight);
 // set the calculated rows attribute (limited by rowLimit)
-if(input.getAttribute("data-max-rows")!==null&&Number(input.getAttribute("data-max-rows")))input.setAttribute("rows",""+Math.min(rows,Number(input.getAttribute("data-max-rows"))));else input.setAttribute("rows",""+rows)};input.addEventListener("input",handleInput);
+if(maxRows)input.setAttribute("rows",""+Math.min(rows,Number(maxRows)));else input.setAttribute("rows",""+rows)};input.addEventListener("input",handleInput);
 // trigger the event to set the initial rows value
 input.dispatchEvent(new Event("input",{bubbles:true}))}
 // shifts the clear button to the right if a scrollbar is present

--- a/docs/statics/js/semantic-forms-main.js
+++ b/docs/statics/js/semantic-forms-main.js
@@ -23,7 +23,7 @@ function toggleDarkMode (mode) {
     document.querySelector('link[href="/css/highlight.js.light.css"]')?.remove()
     document.querySelector('head').insertAdjacentHTML('beforeend', '<link rel="stylesheet" href="/css/highlight.js.light.css">')
     document.querySelector('#mode button').innerHTML = 'Switch to dark mode'
-    const forms = document.querySelectorAll('form')
+    const forms = document.querySelectorAll('.semanticForms')
     for (const form of forms) {
       form.classList.add('light')
       form.classList.remove('dark')
@@ -35,7 +35,7 @@ function toggleDarkMode (mode) {
     document.querySelector('link[href="/css/highlight.js.light.css"]')?.remove()
     document.querySelector('head').insertAdjacentHTML('beforeend', '<link rel="stylesheet" href="/css/highlight.js.dark.css">')
     document.querySelector('#mode button').innerHTML = 'Switch to light mode'
-    const forms = document.querySelectorAll('form')
+    const forms = document.querySelectorAll('.semanticForms')
     for (const form of forms) {
       form.classList.add('dark')
       form.classList.remove('light')

--- a/docs/statics/pages/fullDemo.html
+++ b/docs/statics/pages/fullDemo.html
@@ -347,17 +347,17 @@
             <h3>Other</h3>
             <dl>
               <dt><label for="textarea">Textarea</label></dt>
-              <dd><textarea id="textarea" name="textarea" placeholder="Try typing something!"></textarea></dd>
+              <dd><textarea id="textarea" name="textarea" placeholder="e.g. He just kept talking in one incredibly unbroken sentence moving from topic to topic so that no one had a chance to interrupt it was really quite hypnotic."></textarea></dd>
 
               <dt><label for="prefilledtextarea">Textarea (prefilled)</label></dt>
               <dd>
-                <textarea id="prefilledtextarea" name="prefilledtextarea" placeholder="Try typing something!">Some prefilled content...</textarea>
+                <textarea id="prefilledtextarea" name="prefilledtextarea" placeholder="e.g. He just kept talking in one incredibly unbroken sentence moving from topic to topic so that no one had a chance to interrupt it was really quite hypnotic.">Some prefilled content...</textarea>
                 <label for="prefilledtextarea">Some help text regarding the textarea with some really long text that should overflow and wrap</label>
               </dd>
 
               <dt><label for="textarea-max-rows">Textarea</label></dt>
               <dd>
-                <textarea id="textarea-max-rows" name="textarea-max-rows" placeholder="Try typing something!" data-max-rows="3" placeholder="Try typing something!">Row 1&#10;Row 2&#10;Row 3&#10;Row 4</textarea>
+                <textarea id="textarea-max-rows" name="textarea-max-rows" placeholder="e.g. He just kept talking in one incredibly unbroken sentence moving from topic to topic so that no one had a chance to interrupt it was really quite hypnotic." data-max-rows="3">Row 1&#10;Row 2&#10;Row 3&#10;Row 4</textarea>
                 <label for="textarea-max-rows">This <code>textarea</code> has the <code>data-max-rows</code> set to 3, so the textarea will not expand past 3 rows.</label>
               </dd>
 

--- a/docs/statics/pages/fullDemo.html
+++ b/docs/statics/pages/fullDemo.html
@@ -347,12 +347,24 @@
             <h3>Other</h3>
             <dl>
               <dt><label for="textarea">Textarea</label></dt>
-              <dd><textarea id="textarea" name="textarea" rows="5" cols="50" placeholder="e.g. He just kept talking in one incredibly unbroken sentence moving from topic to topic so that no one had a chance to interrupt it was really quite hypnotic."></textarea></dd>
+              <dd><textarea id="textarea" name="textarea" placeholder="Try typing something!"></textarea></dd>
 
               <dt><label for="prefilledtextarea">Textarea (prefilled)</label></dt>
               <dd>
-                <textarea id="prefilledtextarea" name="prefilledtextarea" rows="5" cols="50" placeholder="e.g. He just kept talking in one incredibly unbroken sentence moving from topic to topic so that no one had a chance to interrupt it was really quite hypnotic.">Some prefilled content...</textarea>
+                <textarea id="prefilledtextarea" name="prefilledtextarea" placeholder="Try typing something!">Some prefilled content...</textarea>
                 <label for="prefilledtextarea">Some help text regarding the textarea with some really long text that should overflow and wrap</label>
+              </dd>
+
+              <dt><label for="textarea-max-rows">Textarea</label></dt>
+              <dd>
+                <textarea id="textarea-max-rows" name="textarea-max-rows" placeholder="Try typing something!" data-max-rows="3" placeholder="Try typing something!">Row 1&#10;Row 2&#10;Row 3&#10;Row 4</textarea>
+                <label for="textarea-max-rows">This <code>textarea</code> has the <code>data-max-rows</code> set to 3, so the textarea will not expand past 3 rows.</label>
+              </dd>
+
+              <dt><label for="disable-autosize-textarea">Disabled autosize textarea</label></dt>
+              <dd>
+                <textarea name="disable-autosize-textarea" id="disable-autosize-textarea" rows="5" placeholder="e.g. He just kept talking in one incredibly unbroken sentence moving from topic to topic so that no one had a chance to interrupt it was really quite hypnotic." data-disable-autosize>Row 1&#10;Row 2&#10;Row 3&#10;Row 4&#10;Row 5&#10;Row 6</textarea>
+                <label for="disable-autosize-textarea">This <code>textarea</code> element has the <code>data-disable-autosize</code> attribute applied, and has <code>rows</code> set to 5.</label>
               </dd>
             </dl>
 
@@ -411,7 +423,7 @@
             </table>
 
             <h4>Table using <code>colgroups</code> to define column width</h4>
-            <table class="semanticForms">
+            <table>
               <colgroup>
                 <col span="1" style="width: 20%">
                 <col span="1" style="width: 50%">
@@ -1235,7 +1247,7 @@
     </main>
     <script>
       document.addEventListener('DOMContentLoaded', () => {
-        const forms = document.querySelectorAll('form')
+        const forms = document.querySelectorAll('.semanticForms')
         for (const form of forms) {
           form.addEventListener('submit', e => e.preventDefault())
         }

--- a/semanticForms.js
+++ b/semanticForms.js
@@ -244,7 +244,17 @@ const semanticForms = () => {
   
             const handleInput = () => {
               // reset rows attribute to get accurate scrollHeight
-              input.setAttribute('rows', '1')
+              let maxRows = input.getAttribute('data-max-rows')
+
+              if (maxRows) {
+                if (isNaN(maxRows) || Number(maxRows) <= 0) {
+                  console.warn(`An invalid value was passed to the "data-max-rows" attribute. This value will be ignored.\n\nProvided value: ${input.getAttribute('data-max-rows')}`, )
+                  maxRows = null
+                }
+              }
+
+              const minRows = input.getAttribute('data-max-rows') && Number(input.getAttribute('data-max-rows')) < 5 ? input.getAttribute('data-max-rows') : '5'
+              input.setAttribute('rows', minRows)
   
               // get the computed values object reference
               const style = window.getComputedStyle(input)
@@ -278,8 +288,8 @@ const semanticForms = () => {
               const rows = Math.round((scrollHeight - blockPadding) / lineHeight)
   
               // set the calculated rows attribute (limited by rowLimit)
-              if (input.getAttribute('data-max-rows') !== null && Number(input.getAttribute('data-max-rows'))) {
-                input.setAttribute("rows", "" + Math.min(rows, Number(input.getAttribute('data-max-rows'))))
+              if (maxRows) {
+                input.setAttribute("rows", "" + Math.min(rows, Number(maxRows)))
               } else {
                 input.setAttribute("rows", "" + rows)
               }

--- a/semanticForms.scss
+++ b/semanticForms.scss
@@ -132,12 +132,21 @@ table.semanticForms.light {
     touch-action: manipulation;
     outline: none;
 
+    &:not([type="range"]):placeholder-shown {
+      padding: 6px 20px;
+    }
+    
     &:not([type="range"]) {
       padding: 6px 30px 6px 20px;
     }
 
     &[type="password"], &[type="text"]:has(~ button.show) {
       padding: 6px 55px 6px 20px;
+    }
+
+    &[type="range"],
+    &[type="color"] {
+      cursor: pointer;
     }
 
     &[disabled] {
@@ -230,9 +239,9 @@ table.semanticForms.light {
 
   textarea {
     resize: vertical;
+    line-height: 1.5;
     width: 100%;
     min-height: 38px;
-    height: 100px;
   }
 
   input[type="search"] {
@@ -541,6 +550,10 @@ table.semanticForms.light {
     // shift text down to match center
     padding-top: 2px;
     font-size: var(--semanticFormsInputFontSize);
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    gap: 5px;
 
     span.required {
       cursor: help;
@@ -551,6 +564,10 @@ table.semanticForms.light {
     span.help {
       cursor: help;
       pointer-events: auto;
+
+      svg {
+        width: 80%;
+      }
     }
   }
 
@@ -680,6 +697,9 @@ table.semanticForms.light {
           user-select: none;
           color: var(--semanticFormsPlaceholderColor);
           touch-action: manipulation;
+          display: flex;
+          align-items: center;
+          gap: 5px;
 
           // TODO: same as below
           // &:has(span.help) {
@@ -707,6 +727,10 @@ table.semanticForms.light {
             // right: 0;
             cursor: help;
             pointer-events: auto;
+
+            svg {
+              width: 80%;
+            }
           }
 
           // // TODO: cover the case where an input is required AND has help text

--- a/semanticForms.scss
+++ b/semanticForms.scss
@@ -65,7 +65,7 @@ form.semanticForms, form.semanticForms.light, table.semanticForms {
 @media (prefers-color-scheme: dark) {
   html:not(.light) {
     body:not(.light) {
-      form.semanticForms, table.semanticForms {
+      form.semanticForms:not(.light), table.semanticForms:not(.light) {
         @include dark-mode;
       }
     }
@@ -78,6 +78,10 @@ html:not(.light) {
       @include dark-mode;
     }
   }
+}
+
+form.semanticForms.dark, table.semanticForms.dark {
+  @include dark-mode;
 }
 // #endregion
 


### PR DESCRIPTION
- Updated textarea elements to autosize based on input text, can be disabled with `data-no-autosize` attribute. Row count can be limited with `data-max-rows` attribute. (closes #173)
- Fixed a visual bug where number input up/down arrows would be shifted when the clear button was not visible. (closes #153)
- Fixed a bug where forms with an explicit light/dark class would be overwritten by the system preference. (closes #168)

(these weren't added to the CHANGELOG, feel free to add if they are useful)
- Adjusted the size and placement of help icons.
- Added pointer cursor styling to range and color inputs.