### PR TITLE
Fix padding on details elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.1.8
+
+- Fixed padding on details element contents.
+
 ## 5.1.7
 
 - Added styling to details elements.

--- a/dist/semantic-forms.css
+++ b/dist/semantic-forms.css
@@ -842,6 +842,12 @@ table.semanticForms.light details summary::after {
   transform-origin: 0.2rem 50%;
   transition: 250ms transform ease;
 }
+form.semanticForms details[open],
+form.semanticForms.light details[open],
+table.semanticForms details[open],
+table.semanticForms.light details[open] {
+  padding-top: 35px;
+}
 form.semanticForms details[open]::details-content,
 form.semanticForms.light details[open]::details-content,
 table.semanticForms details[open]::details-content,

--- a/semanticForms.js
+++ b/semanticForms.js
@@ -241,62 +241,62 @@ const semanticForms = () => {
             input.style.setProperty('min-height', '0')
             input.style.setProperty('max-height', 'none')
             input.style.setProperty('height', 'auto')
-  
+
             const handleInput = () => {
               // reset rows attribute to get accurate scrollHeight
               let maxRows = input.getAttribute('data-max-rows')
 
               if (maxRows) {
                 if (isNaN(maxRows) || Number(maxRows) <= 0) {
-                  console.warn(`An invalid value was passed to the "data-max-rows" attribute. This value will be ignored.\n\nProvided value: ${input.getAttribute('data-max-rows')}`, )
+                  console.warn(`An invalid value was passed to the "data-max-rows" attribute. This value will be ignored.\n\nProvided value: ${input.getAttribute('data-max-rows')}`)
                   maxRows = null
                 }
               }
 
               const minRows = input.getAttribute('data-max-rows') && Number(input.getAttribute('data-max-rows')) < 5 ? input.getAttribute('data-max-rows') : '5'
               input.setAttribute('rows', minRows)
-  
+
               // get the computed values object reference
               const style = window.getComputedStyle(input)
-  
+
               // force content-box for size accurate line-height calculation, remove scrollbars, lock width (subtract inline padding and inline border widths), and remove inline padding and borders to keep width consistent (for text wrapping accuracy)
               const inlinePadding = parseFloat(style['padding-left']) + parseFloat(style['padding-right'])
               const inlineBorderWidth = parseFloat(style['border-left-width']) + parseFloat(style['border-right-width'])
               input.style.setProperty('overflow', 'hidden', 'important')
-              input.style.setProperty('width', (parseFloat(style['width']) - inlinePadding - inlineBorderWidth) + 'px')
+              input.style.setProperty('width', (parseFloat(style.width) - inlinePadding - inlineBorderWidth) + 'px')
               input.style.setProperty('box-sizing', 'content-box')
               input.style.setProperty('padding-inline', '0')
               input.style.setProperty('border-width', '0')
-              
+
               // get the base line height, and top / bottom padding
               const blockPadding = parseFloat(style['padding-top']) + parseFloat(style['padding-bottom'])
-              const lineHeight = style['line-height'] === 'normal' 
-                ? parseFloat(style['height']) // if line-height is not explicitly set, use the computed height value (ignore padding due to content-box)
+              const lineHeight = style['line-height'] === 'normal'
+                ? parseFloat(style.height) // if line-height is not explicitly set, use the computed height value (ignore padding due to content-box)
                 : parseFloat(style['line-height']) // otherwise (line-height is explicitly set), use the computed line-height value
-  
+
               // get the scroll height (rounding to be safe to ensure cross browser consistency)
               const scrollHeight = Math.round(input.scrollHeight)
-  
+
               // undo overflow, width, border-width, box-sizing & inline padding overrides
               input.style.removeProperty('width')
               input.style.removeProperty('box-sizing')
               input.style.removeProperty('padding-inline')
               input.style.removeProperty('border-width')
               input.style.removeProperty('overflow')
-  
+
               // subtract blockPadding from scrollHeight and divide that by our lineHeight to get the row count, round to nearest integer as it will always be within ~.1 of the correct whole number
               const rows = Math.round((scrollHeight - blockPadding) / lineHeight)
-  
+
               // set the calculated rows attribute (limited by rowLimit)
               if (maxRows) {
-                input.setAttribute("rows", "" + Math.min(rows, Number(maxRows)))
+                input.setAttribute('rows', '' + Math.min(rows, Number(maxRows)))
               } else {
-                input.setAttribute("rows", "" + rows)
+                input.setAttribute('rows', '' + rows)
               }
             }
-  
+
             input.addEventListener('input', handleInput)
-  
+
             // trigger the event to set the initial rows value
             input.dispatchEvent(new Event('input', { bubbles: true }))
           }

--- a/semanticForms.scss
+++ b/semanticForms.scss
@@ -466,6 +466,8 @@ table.semanticForms.light {
   }
 
   details[open] {
+    padding-top: 35px; // TODO: remove this when animated detail label is reintroduced
+
     &::details-content {
       visibility: visible;
       opacity: 1;


### PR DESCRIPTION
- Fixed padding on details element contents.

Before:
<img width="742" height="196" alt="image" src="https://github.com/user-attachments/assets/48cbf480-5fcf-4846-b769-d4c241fc3cb4" />


After:
<img width="742" height="196" alt="image" src="https://github.com/user-attachments/assets/751efbdf-5100-4143-b9df-588b0706421f" />
